### PR TITLE
chore: rename package for NPM publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# TeraSky's Backstage Plugins
+# TeraSky's Backstage Plugins - Open Service Portal Fork
+
+This is a fork of [TeraSky's Backstage plugins](https://github.com/TeraSky-OSS/backstage-plugins) maintained by the Open Service Portal organization.
+
+We publish the kubernetes-ingestor plugin as `@open-service-portal/backstage-plugin-kubernetes-ingestor` on NPM.
+
+---
+
+## Original TeraSky Documentation
+
 These plugins are built and tested against Backstage version 1.41.1
 
 ## Plugin overviews

--- a/plugins/kubernetes-ingestor/package.json
+++ b/plugins/kubernetes-ingestor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@terasky/backstage-plugin-kubernetes-ingestor",
+  "name": "@open-service-portal/backstage-plugin-kubernetes-ingestor",
   "version": "2.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -11,15 +11,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TeraSky-OSS/backstage-plugins.git",
+    "url": "git+https://github.com/open-service-portal/backstage-plugins.git",
     "directory": "plugins/kubernetes-ingestor"
   },
-  "homepage": "https://terasky.com",
+  "homepage": "https://github.com/open-service-portal/backstage-plugins",
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "backstage-plugin-kubernetes-ingestor",
     "pluginPackages": [
-      "@terasky/backstage-plugin-kubernetes-ingestor"
+      "@open-service-portal/backstage-plugin-kubernetes-ingestor"
     ]
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Minimal changes to publish TeraSky's kubernetes-ingestor plugin under our NPM organization namespace.

## Changes

- 📦 Renamed package from `@terasky/backstage-plugin-kubernetes-ingestor` to `@open-service-portal/backstage-plugin-kubernetes-ingestor`
- 🔗 Updated repository URLs to point to our fork
- 📝 Added minimal fork documentation in README
- ✅ Kept version at 2.0.0 to match upstream

## Why This Approach

This PR contains ONLY the necessary changes to publish the plugin on NPM. The code remains identical to TeraSky's upstream version. Our customizations will come in a separate PR.

## Testing

```bash
cd plugins/kubernetes-ingestor
yarn build
# Verify package.json has correct name
npm pack --dry-run
```

## Next Steps

1. Merge this PR
2. Publish to NPM: `npm publish --access public`
3. Apply our customizations in a follow-up PR