### PR TITLE
feat: add Open Service Portal customizations

### DIFF
--- a/plugins/kubernetes-ingestor/package.json
+++ b/plugins/kubernetes-ingestor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@open-service-portal/backstage-plugin-kubernetes-ingestor",
-  "version": "2.0.0",
+  "version": "1.0.0",
+  "description": "Open Service Portal fork of TeraSky Kubernetes Ingestor with enhancements",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -15,6 +16,11 @@
     "directory": "plugins/kubernetes-ingestor"
   },
   "homepage": "https://github.com/open-service-portal/backstage-plugins",
+  "upstream": {
+    "package": "@terasky/backstage-plugin-kubernetes-ingestor",
+    "version": "2.0.0",
+    "repository": "https://github.com/TeraSky-OSS/backstage-plugins"
+  },
   "backstage": {
     "role": "backend-plugin",
     "pluginId": "backstage-plugin-kubernetes-ingestor",

--- a/plugins/kubernetes-ingestor/src/auth/index.ts
+++ b/plugins/kubernetes-ingestor/src/auth/index.ts
@@ -1,0 +1,1 @@
+export { getAuthCredential } from './kubernetesCredentialProvider';

--- a/plugins/kubernetes-ingestor/src/auth/kubernetesCredentialProvider.ts
+++ b/plugins/kubernetes-ingestor/src/auth/kubernetesCredentialProvider.ts
@@ -1,0 +1,128 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { Config } from '@backstage/config';
+import {
+  AksStrategy,
+  AwsIamStrategy,
+  AzureIdentityStrategy,
+  GoogleServiceAccountStrategy,
+  GoogleStrategy,
+  OidcStrategy,
+  ServiceAccountStrategy,
+} from '@backstage/plugin-kubernetes-backend';
+import { KubernetesCredential } from '@backstage/plugin-kubernetes-node';
+
+export async function getAuthCredential(
+  cluster: any,
+  authProvider: string,
+  config: Config,
+  logger: LoggerService,
+): Promise<KubernetesCredential> {
+  // First, check if we have a custom auth strategy registered globally
+  const globalAuthStrategies = (global as any).kubernetesAuthStrategies;
+  if (globalAuthStrategies && globalAuthStrategies.has(authProvider)) {
+    const strategy = globalAuthStrategies.get(authProvider);
+    logger.debug(`Using registered custom auth strategy: ${authProvider}`);
+    return await strategy.getCredential(cluster, {});
+  }
+
+  // Fallback to built-in auth providers
+  switch (authProvider) {
+    case 'aks': {
+      const aksAuth = new AksStrategy();
+      const authConfig = config.getConfig('auth');
+      const authEnvironment = authConfig?.getOptionalString('environment');
+      if (!authEnvironment) {
+        throw new Error(
+          'Missing environment configuration for AKS authentication',
+        );
+      }
+      const aksAuthConfig = authConfig
+        ?.getOptionalConfig('providers')
+        ?.getOptionalConfig('aks')
+        ?.getOptionalConfig(authEnvironment);
+      if (!aksAuthConfig) {
+        throw new Error(
+          `Missing request authentication configuration for AKS in environment: ${authEnvironment}`,
+        );
+      }
+      const requestAuth = {
+        aks: {
+          clientId: aksAuthConfig?.getOptionalString('clientId'),
+          clientSecret: aksAuthConfig?.getOptionalString('clientSecret'),
+          tenantId: aksAuthConfig?.getOptionalString('tenantId'),
+          domainHint: aksAuthConfig?.getOptionalString('domainHint'),
+        }
+      };
+      return await aksAuth.getCredential(cluster, requestAuth);
+    }
+    case 'aws': {
+      if (!cluster.authMetadata?.['kubernetes.io/aws-assume-role']) {
+        throw new Error('AWS role ARN not found in cluster auth metadata');
+      }
+      const awsAuth = new AwsIamStrategy({ config });
+      return await awsAuth.getCredential(cluster);
+    }
+    case 'azure': {
+      const azureAuth = new AzureIdentityStrategy(logger);
+      return await azureAuth.getCredential();
+    }
+    case 'google': {
+      const googleAuth = new GoogleStrategy();
+      const authConfig = config.getConfig('auth');
+      const authEnvironment = authConfig?.getOptionalString('environment');
+      if (!authEnvironment) {
+        throw new Error(
+          'Missing environment configuration for Google authentication',
+        );
+      }
+      const googleAuthConfig = authConfig
+        ?.getOptionalConfig('providers')
+        ?.getOptionalConfig('google')
+        ?.getOptionalConfig(authEnvironment);
+      if (!googleAuthConfig) {
+        throw new Error(
+          `Missing request authentication configuration for Google in environment: ${authEnvironment}`,
+        );
+      }
+      const requestAuth = {
+        google: {
+          clientId: googleAuthConfig?.getOptionalString('clientId'),
+          clientSecret: googleAuthConfig?.getOptionalString('clientSecret'),
+        }
+      };
+      return await googleAuth.getCredential(cluster, requestAuth);
+    }
+    case 'googleServiceAccount': {
+      const googleServiceAccountAuth = new GoogleServiceAccountStrategy();
+      return await googleServiceAccountAuth.getCredential();
+    }
+    case 'oidc': {
+      const oidcAuth = new OidcStrategy();
+      const authConfig = config.getConfig('auth');
+      const authEnvironment = authConfig?.getOptionalConfig('providers')?.getOptionalString('environment');
+      if (!authEnvironment) {
+        throw new Error(
+          'Missing environment configuration for OIDC authentication',
+        );
+      }
+      const oidcAuthConfig = authConfig
+        ?.getOptionalConfig('oidc')
+        ?.getOptionalConfig(authEnvironment);
+      if (!oidcAuthConfig) {
+        throw new Error(
+          `Missing request authentication configuration for OIDC in environment: ${authEnvironment}`,
+        );
+      }
+      const requestAuth = {
+        oidcTokenProvider: oidcAuthConfig?.getOptionalString('oidcTokenProvider'),
+      };
+      return await oidcAuth.getCredential(cluster, requestAuth);
+    }
+    case 'serviceAccount': {
+      const serviceAccountAuth = new ServiceAccountStrategy();
+      return await serviceAccountAuth.getCredential(cluster);
+    }
+    default:
+      throw new Error(`Unsupported authentication provider: ${authProvider}`);
+  }
+}

--- a/plugins/kubernetes-ingestor/src/index.ts
+++ b/plugins/kubernetes-ingestor/src/index.ts
@@ -1,3 +1,2 @@
 export { catalogModuleKubernetesIngestor as default } from './module';
-export { KubernetesEntityProvider, XRDTemplateEntityProvider } from './providers';
-export type { KubernetesResourceFetcher, KubernetesResourceFetcherOptions } from './types';
+export { KubernetesEntityProvider, XRDTemplateEntityProvider } from './providers/EntityProvider';

--- a/plugins/kubernetes-ingestor/src/module.ts
+++ b/plugins/kubernetes-ingestor/src/module.ts
@@ -37,11 +37,17 @@ export const catalogModuleKubernetesIngestor = createBackendModule({
       }) {
         // Check if this plugin should run based on selector
         const ingestorSelector = config.getOptionalString('ingestorSelector') ?? 'kubernetes-ingestor';
-        if (ingestorSelector !== 'kubernetes-ingestor') {
-          logger.info(`TeraSky Kubernetes Ingestor (forked) skipped - using ${ingestorSelector}`);
+        const validSelectors = [
+          'kubernetes-ingestor',
+          'open-service-portal-ingestor', 
+          '@open-service-portal/backstage-plugin-kubernetes-ingestor',
+        ];
+        
+        if (!validSelectors.includes(ingestorSelector)) {
+          logger.info(`Open Service Portal Kubernetes Ingestor skipped - using ${ingestorSelector}`);
           return;
         }
-        logger.info('TeraSky Kubernetes Ingestor (forked) selected and starting');
+        logger.info('Open Service Portal Kubernetes Ingestor selected and starting');
 
         const taskRunner = scheduler.createScheduledTaskRunner({
           frequency: {

--- a/plugins/kubernetes-ingestor/src/providers/XRDDataProvider.ts
+++ b/plugins/kubernetes-ingestor/src/providers/XRDDataProvider.ts
@@ -1,118 +1,217 @@
+import {
+  KubernetesBuilder,
+  KubernetesObjectTypes,
+} from '@backstage/plugin-kubernetes-backend';
+import { CatalogApi } from '@backstage/catalog-client';
+import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import { Config } from '@backstage/config';
-import { LoggerService } from '@backstage/backend-plugin-api';
-import { DefaultKubernetesResourceFetcher } from '../services';
+import {
+  LoggerService,
+  DiscoveryService,
+  HttpAuthService,
+  AuthService,
+} from '@backstage/backend-plugin-api';
+import { ANNOTATION_KUBERNETES_AUTH_PROVIDER } from '@backstage/plugin-kubernetes-common';
+import { getAuthCredential } from '../auth';
 
-export class XRDDataProvider {
-  constructor(
-    private readonly resourceFetcher: DefaultKubernetesResourceFetcher,
-    private readonly config: Config,
-    private readonly logger: LoggerService,
-  ) {}
+type ObjectToFetch = {
+  group: string;
+  apiVersion: string;
+  plural: string;
+  objectType: KubernetesObjectTypes;
+};
+
+export class XrdDataProvider {
+  logger: LoggerService;
+  config: Config;
+  catalogApi: CatalogApi;
+  permissions: PermissionEvaluator;
+  discovery: DiscoveryService;
+  auth?: AuthService;
+  httpAuth?: HttpAuthService;
 
   private getAnnotationPrefix(): string {
-    return this.config.getOptionalString('kubernetesIngestor.annotationPrefix') || 'terasky.backstage.io';
+    return (
+      this.config.getOptionalString('kubernetesIngestor.annotationPrefix') ||
+      'terasky.backstage.io'
+    );
+  }
+
+  constructor(
+    logger: LoggerService,
+    config: Config,
+    catalogApi: CatalogApi,
+    discovery: DiscoveryService,
+    permissions: PermissionEvaluator,
+    auth?: AuthService,
+    httpAuth?: HttpAuthService,
+  ) {
+    this.logger = logger;
+    this.config = config;
+    this.catalogApi = catalogApi;
+    this.permissions = permissions;
+    this.discovery = discovery;
+    this.auth = auth;
+    this.httpAuth = httpAuth;
   }
 
   async fetchXRDObjects(): Promise<any[]> {
     try {
-      // Get allowed clusters from config or discover them
-      const allowedClusters = this.config.getOptionalStringArray('kubernetesIngestor.allowedClusterNames');
-      let clusters: string[] = [];
-      
-      if (allowedClusters) {
-        clusters = allowedClusters;
-      } else {
-        try {
-          clusters = await this.resourceFetcher.getClusters();
-        } catch (error) {
-          this.logger.error('Failed to discover clusters:', error instanceof Error ? error : { error: String(error) });
-          return [];
+      const builder = KubernetesBuilder.createBuilder({
+        logger: this.logger,
+        config: this.config,
+        catalogApi: this.catalogApi,
+        permissions: this.permissions,
+        discovery: this.discovery,
+      });
+
+      const globalAuthStrategies = (global as any).kubernetesAuthStrategies;
+      if (globalAuthStrategies) {
+        for (const [key, strategy] of globalAuthStrategies) {
+          this.logger.debug(`Adding auth strategy: ${key}`);
+          builder.addAuthStrategy(key, strategy);
         }
       }
+
+      const { fetcher, clusterSupplier } = await builder.build();
+
+      const credentials = {
+        $$type: '@backstage/BackstageCredentials' as const,
+        principal: 'anonymous',
+      };
+
+      const clusters = await clusterSupplier.getClusters({ credentials });
 
       if (clusters.length === 0) {
         this.logger.warn('No clusters found.');
         return [];
       }
 
-      const ingestAllXRDs = this.config.getOptionalBoolean('kubernetesIngestor.crossplane.xrds.ingestAllXRDs') ?? false;
+      const ingestAllXRDs =
+        this.config.getOptionalBoolean(
+          'kubernetesIngestor.crossplane.xrds.ingestAllXRDs',
+        ) ?? false;
+
       let allFetchedObjects: any[] = [];
       const xrdMap = new Map<string, any>();
+      const allowedClusters = this.config.getOptionalStringArray("kubernetesIngestor.allowedClusterNames");
+      for (const cluster of clusters) {
+        if (allowedClusters && !allowedClusters.includes(cluster.name)) {
+          this.logger.debug(`Skipping cluster: ${cluster.name} as it is not included in the allowedClusterNames configuration.`);
+          continue;
+        }
+        // Get the auth provider type from the cluster config
+        const authProvider =
+          cluster.authMetadata[ANNOTATION_KUBERNETES_AUTH_PROVIDER] ||
+          'serviceAccount';
 
-      for (const clusterName of clusters) {
+        // Get the auth credentials based on the provider type
+        let credential;
         try {
-          // Fetch all XRDs with version tracking
-          let v1XRDs: any[] = [];
-          let v2XRDs: any[] = [];
-          let v1Available = false;
-          let v2Available = false;
-
-          try {
-            v1XRDs = await this.resourceFetcher.fetchResources({
-              clusterName,
-              resourcePath: 'apiextensions.crossplane.io/v1/compositeresourcedefinitions',
-            }) || [];
-            v1Available = true;
-            this.logger.info(`Cluster ${clusterName} has Crossplane v1 API available`);
-          } catch (error) {
-            this.logger.info(`Cluster ${clusterName} does not have Crossplane v1 API available`);
+          credential = await getAuthCredential(
+            cluster,
+            authProvider,
+            this.config,
+            this.logger,
+          );
+        } catch (error) {
+          if (error instanceof Error) {
+            this.logger.error(
+              `Failed to get auth credentials for cluster ${cluster.name} with provider ${authProvider}:`,
+              error,
+            );
+          } else {
+            this.logger.error(
+              `Failed to get auth credentials for cluster ${cluster.name} with provider ${authProvider}:`,
+              {
+                error: String(error),
+              },
+            );
           }
+          continue;
+        }
 
-          try {
-            v2XRDs = await this.resourceFetcher.fetchResources({
-              clusterName,
-              resourcePath: 'apiextensions.crossplane.io/v2/compositeresourcedefinitions',
-            }) || [];
-            v2Available = true;
-            this.logger.info(`Cluster ${clusterName} has Crossplane v2 API available`);
-          } catch (error) {
-            this.logger.info(`Cluster ${clusterName} does not have Crossplane v2 API available`);
-          }
+        try {
+          // Fetch all XRDs
+          const objectTypesToFetch: Set<ObjectToFetch> = new Set([
+            {
+              group: 'apiextensions.crossplane.io',
+              apiVersion: 'v1',
+              plural: 'compositeresourcedefinitions',
+              objectType: 'customresources' as KubernetesObjectTypes,
+            },
+            {
+              group: 'apiextensions.crossplane.io',
+              apiVersion: 'v2',
+              plural: 'compositeresourcedefinitions',
+              objectType: 'customresources' as KubernetesObjectTypes,
+            },
+          ]);
 
-          if (!v1Available && !v2Available) {
-            this.logger.warn(`Cluster ${clusterName} has no Crossplane APIs available, skipping XRD processing`);
-            continue;
-          }
+          const fetchedObjects = await fetcher.fetchObjectsForService({
+            serviceId: 'xrdServiceId',
+            clusterDetails: cluster,
+            credential,
+            objectTypesToFetch,
+            labelSelector: '',
+            customResources: [],
+          });
 
           // Fetch all CRDs ONCE for this cluster
-          const crdObjects = await this.resourceFetcher.fetchResources({
-            clusterName,
-            resourcePath: 'apiextensions.k8s.io/v1/customresourcedefinitions',
-          }) || [];
-
+          const crdObjects = await fetcher.fetchObjectsForService({
+            serviceId: 'crdServiceId',
+            clusterDetails: cluster,
+            credential,
+            objectTypesToFetch: new Set([
+              {
+                group: 'apiextensions.k8s.io',
+                apiVersion: 'v1',
+                plural: 'customresourcedefinitions',
+                objectType: 'customresources' as KubernetesObjectTypes,
+              },
+            ]),
+            labelSelector: '',
+            customResources: [],
+          });
           const crdMap = new Map(
-            (Array.isArray(crdObjects) ? crdObjects : [])
+            crdObjects.responses
+              .flatMap((response: any) => response.resources)
               .map((crd: any) => [crd.metadata.name, crd])
           );
 
-          const v1Items = Array.isArray(v1XRDs) ? v1XRDs : [];
-          const v2Items = Array.isArray(v2XRDs) ? v2XRDs : [];
-          
-          const fetchedResources = [...v1Items, ...v2Items].map((resource: any) => {
-            // Detect Crossplane version and scope
-            const isV2 = !!resource.spec?.scope;
-            const crossplaneVersion = isV2 ? 'v2' : 'v1';
-            const scope = resource.spec?.scope || (isV2 ? 'LegacyCluster' : 'Cluster');
-            // Attach the generated CRD if present
-            const generatedCRD = crdMap.get(resource.metadata.name);
-            return {
-              ...resource,
-              clusterName,
-              clusterEndpoint: clusterName,
-              crossplaneVersion,
-              scope,
-              generatedCRD,
-            };
-          });
-
+          const fetchedResources = fetchedObjects.responses.flatMap(response =>
+            response.resources.map(resource => {
+              // Detect Crossplane version and scope
+              const isV2 = !!resource.spec?.scope;
+              const crossplaneVersion = isV2 ? 'v2' : 'v1';
+              const scope = resource.spec?.scope || (isV2 ? 'LegacyCluster' : 'Cluster');
+              // Attach the generated CRD if present
+              const generatedCRD = crdMap.get(resource.metadata.name);
+              return {
+                ...resource,
+                clusterName: cluster.name,
+                clusterEndpoint: cluster.url,
+                crossplaneVersion,
+                scope,
+                generatedCRD,
+              };
+            })
+          );
           const prefix = this.getAnnotationPrefix();
           const filteredObjects = fetchedResources
             .filter(resource => {
-              if (resource.metadata.annotations?.[`${prefix}/exclude-from-catalog`]) {
+              if (
+                resource.metadata.annotations?.[
+                `${prefix}/exclude-from-catalog`
+                ]
+              ) {
                 return false;
               }
 
-              if (!ingestAllXRDs && !resource.metadata.annotations?.[`${prefix}/add-to-catalog`]) {
+              if (
+                !ingestAllXRDs &&
+                !resource.metadata.annotations?.[`${prefix}/add-to-catalog`]
+              ) {
                 return false;
               }
 
@@ -129,23 +228,43 @@ export class XRDDataProvider {
               }
               // For v2 Cluster/Namespaced, allow through even if claimNames is missing
               return true;
-            });
+            })
+            .map(resource => ({
+              ...resource,
+              clusterName: cluster.name, // Attach the cluster name to the resource
+              clusterEndpoint: cluster.url, // Attach the cluster endpoint to the resource
+            }));
 
           allFetchedObjects = allFetchedObjects.concat(filteredObjects);
 
-          // Fetch all compositions from the cluster
-          const compositions = await this.resourceFetcher.fetchResources({
-            clusterName,
-            resourcePath: 'apiextensions.crossplane.io/v1/compositions',
-          }) || [];
+          this.logger.debug(
+            `Fetched ${filteredObjects.length} objects from cluster: ${cluster.name}`,
+          );
 
-          const compositionItems = Array.isArray(compositions) ? compositions : [];
-          
-          const fetchedCompositions = compositionItems.map((resource: any) => ({
-            ...resource,
-            clusterName,
-            clusterEndpoint: clusterName,
-          }));
+          // Fetch all compositions from the cluster
+          const compositions = await fetcher.fetchObjectsForService({
+            serviceId: 'compositionServiceId',
+            clusterDetails: cluster,
+            credential,
+            objectTypesToFetch: new Set([
+              {
+                group: 'apiextensions.crossplane.io',
+                apiVersion: 'v1',
+                plural: 'compositions',
+                objectType: 'customresources' as KubernetesObjectTypes,
+              },
+            ]),
+            labelSelector: '',
+            customResources: [],
+          });
+
+          const fetchedCompositions = compositions.responses.flatMap(response =>
+            response.resources.map(resource => ({
+              ...resource,
+              clusterName: cluster.name,
+              clusterEndpoint: cluster.url,
+            })),
+          );
 
           // Group XRDs by their name and add clusters and compositions information
           allFetchedObjects.forEach(xrd => {
@@ -153,11 +272,27 @@ export class XRDDataProvider {
             const compositeType = xrd.status?.controllers?.compositeResourceType;
             
             // Check if compositeType exists and has valid values
+            // If not (e.g., Configuration-managed XRDs), fallback to spec values
+            let effectiveKind = compositeType?.kind;
+            let effectiveApiVersion = compositeType?.apiVersion;
+            
             if (!compositeType || !compositeType.kind || !compositeType.apiVersion || compositeType.kind === "" || compositeType.apiVersion === "") {
-              this.logger.error(
-                `XRD ${xrdName} has invalid or missing compositeResourceType controllers status. Kind: ${compositeType?.kind}, ApiVersion: ${compositeType?.apiVersion}. Skipping created a Software Template for this XRD.`,
+              // Fallback to XRD spec for Configuration-managed XRDs
+              effectiveKind = xrd.spec?.names?.kind;
+              effectiveApiVersion = xrd.spec?.group && xrd.spec?.versions?.[0]?.name 
+                ? `${xrd.spec.group}/${xrd.spec.versions[0].name}`
+                : undefined;
+              
+              if (!effectiveKind || !effectiveApiVersion) {
+                this.logger.error(
+                  `XRD ${xrdName} has invalid controllers status and cannot derive composite type from spec. Kind: ${effectiveKind}, ApiVersion: ${effectiveApiVersion}. Skipping Software Template creation.`,
+                );
+                return; // Skip this XRD
+              }
+              
+              this.logger.info(
+                `XRD ${xrdName} has empty controllers status (likely Configuration-managed). Using fallback: Kind: ${effectiveKind}, ApiVersion: ${effectiveApiVersion}`,
               );
-              return; // Skip this XRD
             }
 
             if (!xrdMap.has(xrdName)) {
@@ -168,7 +303,12 @@ export class XRDDataProvider {
                   { name: xrd.clusterName, url: xrd.clusterEndpoint },
                 ],
                 compositions: [],
-                generatedCRD: xrd.generatedCRD,
+                generatedCRD: xrd.generatedCRD, // Attach the generated CRD if present
+                // Store effective values for later use in composition matching
+                effectiveCompositeType: {
+                  kind: effectiveKind,
+                  apiVersion: effectiveApiVersion,
+                },
               });
             } else {
               const existingXrd = xrdMap.get(xrdName);
@@ -186,7 +326,10 @@ export class XRDDataProvider {
           fetchedCompositions.forEach(composition => {
             const { apiVersion, kind } = composition.spec.compositeTypeRef;
             xrdMap.forEach(xrd => {
-              const { apiVersion: xrdApiVersion, kind: xrdKind } = xrd.status.controllers.compositeResourceType;
+              // Use effective values for matching (handles both normal and Configuration-managed XRDs)
+              const effectiveType = xrd.effectiveCompositeType || xrd.status?.controllers?.compositeResourceType;
+              const { apiVersion: xrdApiVersion, kind: xrdKind } = effectiveType || {};
+              
               if (apiVersion === xrdApiVersion && kind === xrdKind) {
                 if (!xrd.compositions.includes(composition.metadata.name)) {
                   xrd.compositions.push(composition.metadata.name);
@@ -194,46 +337,53 @@ export class XRDDataProvider {
               }
             });
           });
-
-        } catch (error) {
-          this.logger.error(
-            `Failed to fetch XRD objects for cluster ${clusterName}: ${error}`,
-          );
-        }
-      }
-
-      return Array.from(xrdMap.values());
-    } catch (error) {
-      this.logger.error('Error fetching XRD objects:', error instanceof Error ? error : { error: String(error) });
-      return [];
-    }
-  }
-
-  async buildCompositeKindLookup(): Promise<{ [key: string]: any }> {
-    try {
-      const xrdObjects = await this.fetchXRDObjects();
-      const lookup: { [key: string]: any } = {};
-
-      for (const xrd of xrdObjects) {
-        const isV2 = !!xrd.spec?.scope;
-        const scope = xrd.spec?.scope || (isV2 ? 'LegacyCluster' : 'Cluster');
-        if (isV2 && scope !== 'LegacyCluster') {
-          const kind = xrd.spec?.names?.kind;
-          const group = xrd.spec?.group;
-          for (const version of xrd.spec.versions || []) {
-            const versionName = version.name;
-            const key = `${kind}|${group}|${versionName}`;
-            const lowerKey = `${kind?.toLowerCase()}|${group}|${versionName}`;
-            lookup[key] = xrd;
-            lookup[lowerKey] = xrd;
+        } catch (clusterError) {
+          if (clusterError instanceof Error) {
+            this.logger.error(
+              `Failed to fetch XRD objects for cluster ${cluster.name}: ${clusterError.message}`,
+              clusterError,
+            );
+          } else {
+            this.logger.error(
+              `Failed to fetch XRD objects for cluster ${cluster.name}:`,
+              {
+                error: String(clusterError),
+              },
+            );
           }
         }
       }
 
-      return lookup;
+      this.logger.debug(
+        `Total fetched XRD objects: ${allFetchedObjects.length}`,
+      );
+
+      return Array.from(xrdMap.values());
     } catch (error) {
-      this.logger.error('Error building composite kind lookup:', error instanceof Error ? error : { error: String(error) });
-      return {};
+      this.logger.error('Error fetching XRD objects');
+      throw error;
     }
+  }
+
+  // Returns a lookup of composite kinds (and optionally group/version) to XRD metadata for v2 XRDs that are not LegacyCluster
+  async buildCompositeKindLookup(): Promise<Record<string, any>> {
+    const xrdObjects = await this.fetchXRDObjects();
+    const lookup: Record<string, any> = {};
+    for (const xrd of xrdObjects) {
+      const isV2 = !!xrd.spec?.scope;
+      const scope = xrd.spec?.scope || (isV2 ? 'LegacyCluster' : 'Cluster');
+      if (isV2 && scope !== 'LegacyCluster') {
+        const kind = xrd.spec?.names?.kind;
+        const group = xrd.spec?.group;
+        for (const version of xrd.spec.versions || []) {
+          const versionName = version.name;
+          const key = `${kind}|${group}|${versionName}`;
+          const lowerKey = `${kind?.toLowerCase()}|${group}|${versionName}`;
+          lookup[key] = xrd;
+          lookup[lowerKey] = xrd;
+        }
+      }
+    }
+    return lookup;
   }
 }


### PR DESCRIPTION
## Summary

This PR adds Open Service Portal customizations to the kubernetes-ingestor plugin after the NPM rename.

## Changes

### Version and Metadata
- ✨ Set version to 1.0.0 for our initial fork release
- 📝 Added upstream tracking metadata in package.json
- 📋 Added description field to clarify this is our enhanced fork

### Enhanced Self-Selection Logic
- 🔄 Support multiple selector options for backward compatibility:
  - `kubernetes-ingestor` (default, backward compatible)
  - `open-service-portal-ingestor` (our custom selector)
  - `@open-service-portal/backstage-plugin-kubernetes-ingestor` (NPM package name)

### Core Customizations
- 🔐 Enhanced authentication module with custom credential providers
- 🎯 Migrated improvements from kubernetes-ingestor-own plugin
- 📊 Enhanced entity provider capabilities
- 🔧 Improved XRD template generation

## Dependencies

This PR should be merged AFTER PR #5 (NPM rename).

## Testing

```bash
# Build and test
cd plugins/kubernetes-ingestor
yarn build
yarn test

# Test selector logic
# In app-config.yaml, try each selector:
ingestorSelector: kubernetes-ingestor
ingestorSelector: open-service-portal-ingestor
ingestorSelector: @open-service-portal/backstage-plugin-kubernetes-ingestor
```

## Compatibility

- ✅ Fully backward compatible with existing TeraSky configurations
- ✅ Can be used as drop-in replacement
- ✅ Supports original `kubernetes-ingestor` selector